### PR TITLE
2 fix requests for Pr 236

### DIFF
--- a/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
+++ b/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
@@ -24,6 +24,9 @@
         state: "{{ item.state | d('present') }}"
         sections:
           - options: "{{ lookup('template', 'output_elasticsearch.j2') }}"
+        mode: "0600"
+        owner: "root"
+        group: "root"
   include_tasks:
     file: "{{ role_path }}/tasks/deploy.yml"
   loop: '{{ rsyslog_output_elasticsearch }}'

--- a/roles/rsyslog/templates/output_elasticsearch.j2
+++ b/roles/rsyslog/templates/output_elasticsearch.j2
@@ -87,12 +87,10 @@ ruleset(name="{{ item.name }}") {
             tls.mycert="{{ __mycert }}"
             tls.myprivkey="{{ __myprivkey }}"
 {%   if item.uid is defined %}
-{%     set __uid = item.uid %}
-            uid="{{ __uid }}"
+            uid="{{ item.uid }}"
 {%   endif %}
 {%   if item.pwd is defined %}
-{%     set __pwd = item.pwd %}
-            pwd="{{ __pwd }}"
+            pwd="{{ item.pwd }}"
 {%   endif %}
 {% endif %}
         )

--- a/roles/rsyslog/templates/output_elasticsearch.j2
+++ b/roles/rsyslog/templates/output_elasticsearch.j2
@@ -92,8 +92,8 @@ ruleset(name="{{ item.name }}") {
 {%   if item.pwd is defined %}
 {%     set __pwd = item.pwd %}
 {%   endif %}
-            tls.uid="{{ __uid }}"
-            tls.pwd="{{ __pwd }}"
+            uid="{{ __uid }}"
+            pwd="{{ __pwd }}"
 {% endif %}
         )
     }

--- a/roles/rsyslog/templates/output_elasticsearch.j2
+++ b/roles/rsyslog/templates/output_elasticsearch.j2
@@ -88,12 +88,12 @@ ruleset(name="{{ item.name }}") {
             tls.myprivkey="{{ __myprivkey }}"
 {%   if item.uid is defined %}
 {%     set __uid = item.uid %}
+            uid="{{ __uid }}"
 {%   endif %}
 {%   if item.pwd is defined %}
 {%     set __pwd = item.pwd %}
-{%   endif %}
-            uid="{{ __uid }}"
             pwd="{{ __pwd }}"
+{%   endif %}
 {% endif %}
         )
     }

--- a/roles/rsyslog/templates/output_elasticsearch.j2
+++ b/roles/rsyslog/templates/output_elasticsearch.j2
@@ -86,6 +86,14 @@ ruleset(name="{{ item.name }}") {
             tls.cacert="{{ __cacert }}"
             tls.mycert="{{ __mycert }}"
             tls.myprivkey="{{ __myprivkey }}"
+{%   if item.uid is defined %}
+{%     set __uid = item.uid %}
+{%   endif %}
+{%   if item.pwd is defined %}
+{%     set __pwd = item.pwd %}
+{%   endif %}
+            tls.uid="{{ __uid }}"
+            tls.pwd="{{ __pwd }}"
 {% endif %}
         )
     }


### PR DESCRIPTION
- 31-output-elasticsearch-elasticsearch_output*.conf: set mode to 0600.
- output_elasticsearch.j2: eliminate unnecessary __uid and __pwd setting.
