### PR TITLE
Put multiple tasks under the condition, item.tls is defined | ternary(item.tls, item.use_cert | d(true)) in a block.

### DIFF
--- a/roles/rsyslog/tasks/set_certs.yml
+++ b/roles/rsyslog/tasks/set_certs.yml
@@ -2,59 +2,53 @@
 - block:
     # This block collect certificates from local location and
     # copies them to the target host
-    - name: "Copy ca_cert on the control host to the specified path
-      on the target host"
-      copy:
-        src: '{{ item.ca_cert_src }}'
-        dest: '{{ item.ca_cert |
-          d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir) }}'
-        mode: '0444'
-      with_items:
-        - '{{ __rsyslog_cert_subject }}'
-      when:
-        - item.ca_cert_src | d()
-        - (item.tls is defined) | ternary(item.tls, item.use_cert | d(true))
+    - block:
+        - name: "Copy ca_cert on the control host to the specified path
+          on the target host"
+          copy:
+            src: '{{ item.ca_cert_src }}'
+            dest: '{{ item.ca_cert |
+              d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir) }}'
+            mode: '0444'
+          with_items:
+            - '{{ __rsyslog_cert_subject }}'
+          when: item.ca_cert_src | d()
 
-    - name: "Copy cert on the control host to the specified path
-      on the target host"
-      copy:
-        src: '{{ item.cert_src }}'
-        dest: '{{ item.cert |
-          d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir) }}'
-        mode: '0444'
-      with_items:
-        - '{{ __rsyslog_cert_subject }}'
-      when:
-        - item.cert_src | d()
-        - (item.tls is defined) | ternary(item.tls, item.use_cert | d(true))
+        - name: "Copy cert on the control host to the specified path
+          on the target host"
+          copy:
+            src: '{{ item.cert_src }}'
+            dest: '{{ item.cert |
+              d(__rsyslog_default_pki_path + __rsyslog_default_pki_cert_dir) }}'
+            mode: '0444'
+          with_items:
+            - '{{ __rsyslog_cert_subject }}'
+          when: item.cert_src | d()
 
-    - name: "Copy key on the control host to the specified path
-      on the target host"
-      copy:
-        src: '{{ item.private_key_src }}'
-        dest: '{{ item.private_key |
-          d(__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir) }}'
-        mode: '0400'
-      with_items:
-        - '{{ __rsyslog_cert_subject }}'
-      when:
-        - item.private_key_src | d()
-        - (item.tls is defined) | ternary(item.tls, item.use_cert | d(true))
+        - name: "Copy key on the control host to the specified path
+          on the target host"
+          copy:
+            src: '{{ item.private_key_src }}'
+            dest: '{{ item.private_key |
+              d(__rsyslog_default_pki_path + __rsyslog_default_pki_key_dir) }}'
+            mode: '0400'
+          with_items:
+            - '{{ __rsyslog_cert_subject }}'
+          when: item.private_key_src | d()
 
-    - name: Check certs - tls is true, but triplets are not given
-      fail:
-        msg: "Error: you specified tls: true; you must specify all
-          3 of ca_cert, cert, private_key, or all 3 of ca_cert_src,
-          cert_src, private_key_src, or set tls: false in the
-          configuration named {{ item.name }}"
-      with_items:
-        - '{{ __rsyslog_cert_subject }}'
-      when:
-        - (item.tls is defined) | ternary(item.tls, item.use_cert | d(true))
-        - not ((item.ca_cert | d() and item.cert | d() and
-                item.private_key | d()) or
-               (item.ca_cert_src | d() and item.cert_src | d() and
-                item.private_key_src | d()))
+        - name: Check certs - tls is true, but triplets are not given
+          fail:
+            msg: "Error: you specified tls: true; you must specify all
+              3 of ca_cert, cert, private_key, or all 3 of ca_cert_src,
+              cert_src, private_key_src, or set tls: false in the
+              configuration named {{ item.name }}"
+          with_items:
+            - '{{ __rsyslog_cert_subject }}'
+          when: not ((item.ca_cert | d() and item.cert | d() and
+                      item.private_key | d()) or
+                     (item.ca_cert_src | d() and item.cert_src | d() and
+                      item.private_key_src | d()))
+      when: item.tls is defined | ternary(item.tls, item.use_cert | d(true))
 
     - name: Check certs - key/certs data are provided, but tls is false
       fail:


### PR DESCRIPTION
Put multiple tasks under the condition,
    `item.tls is defined | ternary(item.tls, item.use_cert | d(true))`
in one block.
