### PR TITLE
Fixing a bug in "Check certs - key/certs data are provided, but tls is false" found by @avlitman.

### DIFF
--- a/roles/rsyslog/tasks/set_certs.yml
+++ b/roles/rsyslog/tasks/set_certs.yml
@@ -57,10 +57,8 @@
       with_items:
         - '{{ __rsyslog_cert_subject }}'
       when:
-        - not ((item.tls is defined) | ternary(item.tls, item.use_cert |
-          d(true)))
-        - item.ca_cert | d() or item.cert | d() or item.private_key | d()
-        - item.ca_cert_src | d() or
-          item.cert_src | d() or
-          item.private_key_src | d()
+        - not (item.tls is defined | ternary(item.tls, item.use_cert | d(true)))
+        - (item.ca_cert | d() or item.cert | d() or item.private_key | d()) or
+          (item.ca_cert_src | d() or item.cert_src | d() or
+           item.private_key_src | d())
   when: __rsyslog_cert_subject | d([])


### PR DESCRIPTION
This case must have failed the Check certs task.
> tls is false and certs+key defined: task was skipped.