### PR TITLE
Change proposals on the request https://github.com/linux-system-roles/logging/pull/236#issuecomment-908216688

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ Available options:
 - `ca_cert_src`: Local CA cert file path which is copied to the target host. If `ca_cert` is specified, it is copied to the location. Otherwise, to logging_config_dir.
 - `cert_src`: Local cert file path which is copied to the target host. If `cert` is specified, it is copied to the location. Otherwise, to logging_config_dir.
 - `private_key_src`: Local key file path which is copied to the target host. If `private_key` is specified, it is copied to the location. Otherwise, to logging_config_dir.
+- `uid`: If basic HTTP authentication is deployed, the user name is specified with this key.
+
+logging_elasticsearch_password: If basic HTTP authentication is deployed, the password is specified with this global variable. Please be careful that this `logging_elasticsearch_password` is a global variable to be placed at the same level as `logging_output`, `logging_input`, and `logging_flows` are. Another things to be aware of are this `logging_elasticsearch_password` is shared among all the elasticsearch outputs. That is, the elasticsearch servers should share one password if there are multiple of servers. Plus, the uid and password are configured if both of them are found in the playbook. For instance, if there are multiple elasticsearch outputs and one of them is missing the `uid` key, then the configured output does not have the uid and password.
 
 #### files type
 

--- a/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
+++ b/roles/rsyslog/tasks/outputs/elasticsearch/main.yml
@@ -28,5 +28,27 @@
         owner: "root"
         group: "root"
   include_tasks:
+    file: "{{ role_path }}/tasks/deploy.yml"
+  loop: '{{ rsyslog_output_elasticsearch }}'
+  when: (logging_elasticsearch_password is not defined) or
+        (logging_elasticsearch_password | length == 0)
+
+- name: Create elasticsearch output configuration files in /etc/rsyslog.d (no_log)
+  vars:
+    __rsyslog_packages: []
+    __rsyslog_rules:
+      - name: "output-elasticsearch-{{ item.name }}"
+        type: "output"
+        weight: "31"
+        state: "{{ item.state | d('present') }}"
+        sections:
+          - options: "{{ lookup('template', 'output_elasticsearch.j2') }}"
+        mode: "0600"
+        owner: "root"
+        group: "root"
+  include_tasks:
     file: "{{ role_path }}/tasks/deploy_nolog.yml"
   loop: '{{ rsyslog_output_elasticsearch }}'
+  when:
+    - logging_elasticsearch_password is defined
+    - logging_elasticsearch_password | length > 0

--- a/tests/tests_ovirt_elasticsearch.yml
+++ b/tests/tests_ovirt_elasticsearch.yml
@@ -175,6 +175,16 @@
       command: /bin/grep 'server="logging-es-ops"' {{ __test_es_ops_conf }}
       changed_when: false
 
+    - name: Check password is in "{{ __test_es_conf }}"
+      command: /bin/grep 'pwd="password0"'  {{ __test_es_conf }}
+      changed_when: false
+
+    - name: Check pwd= is not in "{{ __test_es_ops_conf }}"
+      command: /bin/grep "pwd="  {{ __test_es_ops_conf }}
+      register: __result
+      changed_when: false
+      failed_when: __result.rc != 1
+
     - name: END TEST CASE 0; Ensure basic ovirt configuration works
       vars:
         logging_enabled: false


### PR DESCRIPTION
- The elasticsearch output calls no_log version of deploy.yml only
  if the user has provided a password.
- Add the uid and logging_elasticsearch_password to README.md.
- Add the test case to tests_ovirt_elasticsearch.yml.

@sradco, @avlitman, could you please review this pr?

I checked the log outputs and did not see the password string there. If you could double-check it, I'd appreciate it.
